### PR TITLE
Include options in run fn and snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,29 @@
+# 0.0.7
+
+- Include `options` in the snapshot.
+- Pass `options` to node's `run` functions.
+
 # 0.0.6
 
-* Added `meta` option for `runTopology`.
+- Added `meta` option for `runTopology`.
 
 # 0.0.5
 
-* Changed `updateStateFn` to `updateState`.
+- Changed `updateStateFn` to `updateState`.
 
 # 0.0.4
 
-* Added `cleanup` fn for resources that will run when the topology terminates.
+- Added `cleanup` fn for resources that will run when the topology terminates.
 
 # 0.0.3
 
-* Consist result type for `resumeTopology`.
+- Consist result type for `resumeTopology`.
 
 # 0.0.2
 
-* Re-export types in index.ts.
-* Switched over to Jest for testing.
+- Re-export types in index.ts.
+- Switched over to Jest for testing.
 
 # 0.0.1
 
-* Initial release
+- Initial release

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ interface RunInput {
   updateState: UpdateState
   state?: any
   signal: AbortSignal
-  meta?: any
+  options?: Options
 }
 ```
 
@@ -163,21 +163,21 @@ A successful run of the above will produce a snapshot that looks like this:
   "started": "2022-05-20T17:16:48.531Z",
   "dag": {
     "api": { "deps": [] },
-    "details": { "deps": [ "api" ] },
-    "attachments": { "deps": [ "api" ] },
-    "writeToDB": { "deps": [ "details", "attachments" ] }
+    "details": { "deps": ["api"] },
+    "attachments": { "deps": ["api"] },
+    "writeToDB": { "deps": ["details", "attachments"] }
   },
   "data": {
     "api": {
       "started": "2022-05-20T17:16:48.532Z",
       "input": [],
       "status": "completed",
-      "output": [ 1, 2, 3 ],
+      "output": [1, 2, 3],
       "finished": "2022-05-20T17:16:48.533Z"
     },
     "details": {
       "started": "2022-05-20T17:16:48.534Z",
-      "input": [ [ 1, 2, 3 ] ],
+      "input": [[1, 2, 3]],
       "status": "completed",
       "state": {
         "index": 2,
@@ -196,7 +196,7 @@ A successful run of the above will produce a snapshot that looks like this:
     },
     "attachments": {
       "started": "2022-05-20T17:16:48.534Z",
-      "input": [ [ 1, 2, 3 ] ],
+      "input": [[1, 2, 3]],
       "status": "completed",
       "state": {
         "index": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "topology-runner",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topology-runner",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Run a topology consisting of a directed acyclic graph",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -272,11 +272,19 @@ describe('runTopology', () => {
       },
       nodes: {
         api: {
-          run: async ({ data, resources, meta }) => ({ data, resources, meta }),
+          run: async ({ data, resources, options }) => ({
+            data,
+            resources,
+            options,
+          }),
           resources: ['elasticCloud'],
         },
         details: {
-          run: async ({ data, resources, meta }) => ({ data, resources, meta }),
+          run: async ({ data, resources, options }) => ({
+            data,
+            resources,
+            options,
+          }),
           resources: ['mongoDb'],
         },
       },
@@ -295,7 +303,7 @@ describe('runTopology', () => {
           output: {
             data: [1, 2, 3],
             resources: { elasticCloud: 'elastic' },
-            meta: { launchMissleCode: 1234 },
+            options: { meta: { launchMissleCode: 1234 } },
           },
         },
         details: {
@@ -303,7 +311,7 @@ describe('runTopology', () => {
             {
               data: [1, 2, 3],
               resources: { elasticCloud: 'elastic' },
-              meta: { launchMissleCode: 1234 },
+              options: { meta: { launchMissleCode: 1234 } },
             },
           ],
           status: 'completed',
@@ -312,15 +320,15 @@ describe('runTopology', () => {
               {
                 data: [1, 2, 3],
                 resources: { elasticCloud: 'elastic' },
-                meta: { launchMissleCode: 1234 },
+                options: { meta: { launchMissleCode: 1234 } },
               },
             ],
             resources: { mongoDb: 'mongo' },
-            meta: { launchMissleCode: 1234 },
+            options: { meta: { launchMissleCode: 1234 } },
           },
         },
       },
-      meta: { launchMissleCode: 1234 },
+      options: { meta: { launchMissleCode: 1234 } },
     })
   })
   test('bad arguments', () => {

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -241,7 +241,7 @@ const _runTopology = (spec: Spec, snapshot: Snapshot, dag: DAG): Response => {
           updateState,
           state,
           signal: abortController.signal,
-          meta: snapshot?.meta
+          options: snapshot?.options,
         }
         // Update snapshot
         events.running(data)
@@ -313,7 +313,7 @@ export const runTopology = (spec: Spec, inputDag: DAG, options?: Options) => {
     started: new Date(),
     dag,
     data,
-    meta: options?.meta
+    options,
   }
   // Run the topology
   return _runTopology(spec, snapshot, dag)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface RunInput {
   updateState: UpdateState
   state?: any
   signal: AbortSignal
-  meta?: any
+  options?: Options
 }
 
 type Millis = number
@@ -41,8 +41,8 @@ export interface Options {
 }
 
 export type Response = {
-  emitter: EventEmitter<Events,any>,
-  promise: Promise<Snapshot>,
+  emitter: EventEmitter<Events, any>
+  promise: Promise<Snapshot>
   getSnapshot: () => Snapshot
 }
 export type Status = 'pending' | 'running' | 'completed' | 'errored'
@@ -65,7 +65,7 @@ export interface Snapshot {
   dag: DAG
   data: SnapshotData
   error?: any
-  meta?: any
+  options?: Options
 }
 
 export type ObjectOfPromises = Record<string | number, Promise<any>>


### PR DESCRIPTION
We need to include options in the snapshot for a resume scenario. For example, resuming a snapshot where `{include,exclude}Nodes` has been used.