### PR TITLE
Misc fixes and improvements

### DIFF
--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -370,7 +370,7 @@ describe('runTopology', () => {
       },
     }
     const { promise } = runTopology(spec, dag)
-    await expect(promise).rejects.toThrow('Timeout')
+    await expect(promise).rejects.toThrow('Errored nodes: ["api"]')
   })
   test('completed', async () => {
     const { promise } = runTopology(spec, dag)
@@ -466,7 +466,6 @@ describe('getResumeSnapshot', () => {
           state: 0,
         },
       },
-      error: 'Failed processing id: 1',
     }
     const snapshot = getResumeSnapshot(errorSnapshot)
     expect(snapshot).toMatchObject({
@@ -539,7 +538,7 @@ describe('resumeTopology', () => {
 
   test('resume after initial error', async () => {
     const { promise, getSnapshot } = runTopology(modifiedSpec, dag)
-    await expect(promise).rejects.toThrow('Failed processing id: 2')
+    await expect(promise).rejects.toThrow('Errored nodes: ["attachments"]')
     const snapshot = getSnapshot()
     expect(snapshot).toMatchObject({
       status: 'errored',
@@ -567,6 +566,7 @@ describe('resumeTopology', () => {
         attachments: {
           input: [[1, 2, 3]],
           status: 'errored',
+          error: 'Error: Failed processing id: 2',
           state: {
             index: 0,
             output: {
@@ -575,7 +575,6 @@ describe('resumeTopology', () => {
           },
         },
       },
-      error: 'Failed processing id: 2',
     })
     const { promise: resumeProm } = await resumeTopology(modifiedSpec, snapshot)
     const resumeSnapshot = await resumeProm

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,8 +41,8 @@ export interface Options {
 }
 
 export type Response = {
-  emitter: EventEmitter<Events,any>,
-  promise: Promise<Snapshot>,
+  emitter: EventEmitter<Events, any>
+  promise: Promise<Snapshot>
   getSnapshot: () => Snapshot
 }
 export type Status = 'pending' | 'running' | 'completed' | 'errored'
@@ -54,6 +54,7 @@ export interface NodeData {
   input: any
   output?: any
   state?: any
+  error?: any
 }
 
 export type SnapshotData = Record<string, NodeData>
@@ -64,7 +65,6 @@ export interface Snapshot {
   finished?: Date
   dag: DAG
   data: SnapshotData
-  error?: any
   meta?: any
 }
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,26 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { setTimeout } from 'node:timers/promises'
-import { missingKeys, findKeys, raceObject } from './util'
-import { ObjectOfPromises } from './types'
-
-describe('raceObject', () => {
-  test('return key of first resolved', async () => {
-    const promises: ObjectOfPromises = {
-      tom: setTimeout(250),
-      joe: setTimeout(350),
-      frank: setTimeout(100),
-    }
-    expect(await raceObject(promises)).toBe('frank')
-  })
-  test('return key of first rejected', async () => {
-    const promises: ObjectOfPromises = {
-      tom: setTimeout(250),
-      joe: Promise.reject('fail'),
-      frank: setTimeout(100),
-    }
-    await expect(raceObject(promises)).rejects.toBe('fail')
-  })
-})
+import { missingKeys, findKeys } from './util'
 
 describe('findKeys', () => {
   test('should find keys', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,16 +1,4 @@
 import _ from 'lodash/fp'
-import { ObjectOfPromises } from './types'
-
-/**
- * Return the key of the first promise from the object that resolves.
- */
-export const raceObject = async (obj: ObjectOfPromises): Promise<string> => {
-  const objToArr = _.flow(
-    _.toPairs,
-    _.map(([key, prom]) => prom.then(() => key))
-  )
-  return Promise.race(objToArr(obj))
-}
 
 /**
  * Find keys where values match pred. pred can be a lodash iteratee.


### PR DESCRIPTION
It is an anti-pattern to pass an async function to the `Promise` constructor, because errors thrown inside the async function do not fail the wrapper Promise. This PR changes a manually constructed promise inside `_runTopology` to be an async function instead.

When running a topology, there may be nodes that fail while other nodes are still running. Right now, we fail fast. This PR changes that so we wait for all the promises to resolve, which is more consistent with how an event loop behaves.

Now since many nodes can be in an errored state, we removed the top-level `error` property on the snapshot and instead set an `error` property per-node.
