### PR TITLE
Don't emit data when finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.0
+
+* Changed `meta` to `context`. This is just a blob that is passed
+to `runTopology` and `resumeTopology` without needing to be serialized.
+
 # 0.3.0
 
 * `runTopology` and `resumeTopology` return `Promise<void>` from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0
+
+* `runTopology` and `resumeTopology` return `Promise<void>` from
+the `promise` property.
+* Don't emit `data` when finished.
+
 # 0.2.0
 
 * Always emit `data`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
-# 0.4.0
-
-* Changed `meta` to `context`. This is just a blob that is passed
-to `runTopology` and `resumeTopology` without needing to be serialized.
-
 # 0.3.0
 
 * `runTopology` and `resumeTopology` return `Promise<void>` from
 the `promise` property.
 * Don't emit `data` when finished.
+* Changed `meta` to `context`. This is just a blob that is passed
+to `runTopology` and `resumeTopology` without needing to be serialized.
 
 # 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ If a node throws an error it will be caught and no further processing on that
 node will be done. Parallel nodes will continue to run until they either complete
 or throw an error.
 
-An event emitter emits a new "data" snapshot every time a node starts, completes, errors,
-updates its state. The final snapshot is not emitted. This will be returned by the promise.
-An "error" or "done" event will be emitted when the DAG either fails to complete
-or sucessfully completes. Note that the outputted snapshot is mutated internally for
+An event emitter emits a new "data" snapshot every time a node starts, completes, errors, or
+updates its state. Use `getSnapshot` to get the final snapshot, regardless of whether the
+topology fails or succeeds. An "error" or "done" event will be emitted when the DAG either
+fails to complete or sucessfully completes. Note that the outputted snapshot is mutated internally for
 efficiency and should not be modified.
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ node will be done. Parallel nodes will continue to run until they either complet
 or throw an error.
 
 An event emitter emits a new "data" snapshot every time a node starts, completes, errors,
-updates its state, or the entire DAG finishes. An "errored" and "completed" event
-will be emitted when the DAG either fails to complete or sucessfully completes. Note
-that the outputted snapshot is mutated internally for efficiency and should not be
-modified.
+updates its state. The final snapshot is not emitted. This will be returned by the promise.
+An "error" or "done" event will be emitted when the DAG either fails to complete
+or sucessfully completes. Note that the outputted snapshot is mutated internally for
+efficiency and should not be modified.
 
 ```typescript
 import { runTopology, DAG, Spec } from 'topology-runner'
@@ -150,7 +150,7 @@ const spec: Spec = {
   },
 }
 
-const { emitter, promise } = runTopology(spec, dag)
+const { emitter, promise, getSnapshot } = runTopology(spec, dag)
 
 const persistSnapshot = (snapshot) => {
   // Could be Redis, MongoDB, etc.
@@ -161,7 +161,13 @@ const persistSnapshot = (snapshot) => {
 // Persist to a datastore for resuming. See below.
 emitter.on('data', persistSnapshot)
 
-const snapshot = await promise
+try {
+  // Wait for the topology to finish
+  await promise
+} finally {
+  // Persist the final snapshot
+  await persistSnapshot(getSnapshot())
+}
 ```
 
 A successful run of the above will produce a snapshot that looks like this:
@@ -172,21 +178,21 @@ A successful run of the above will produce a snapshot that looks like this:
   "started": "2022-05-20T17:16:48.531Z",
   "dag": {
     "api": { "deps": [] },
-    "details": { "deps": [ "api" ] },
-    "attachments": { "deps": [ "api" ] },
-    "writeToDB": { "deps": [ "details", "attachments" ] }
+    "details": { "deps": ["api"] },
+    "attachments": { "deps": ["api"] },
+    "writeToDB": { "deps": ["details", "attachments"] }
   },
   "data": {
     "api": {
       "started": "2022-05-20T17:16:48.532Z",
       "input": [],
       "status": "completed",
-      "output": [ 1, 2, 3 ],
+      "output": [1, 2, 3],
       "finished": "2022-05-20T17:16:48.533Z"
     },
     "details": {
       "started": "2022-05-20T17:16:48.534Z",
-      "input": [ [ 1, 2, 3 ] ],
+      "input": [[1, 2, 3]],
       "status": "completed",
       "state": {
         "index": 2,
@@ -205,7 +211,7 @@ A successful run of the above will produce a snapshot that looks like this:
     },
     "attachments": {
       "started": "2022-05-20T17:16:48.534Z",
-      "input": [ [ 1, 2, 3 ] ],
+      "input": [[1, 2, 3]],
       "status": "completed",
       "state": {
         "index": 2,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ interface RunInput {
   updateState: UpdateState
   state?: any
   signal: AbortSignal
-  meta?: any
+  context?: any
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topology-runner",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "topology-runner",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topology-runner",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "topology-runner",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topology-runner",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "topology-runner",
-      "version": "0.4.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topology-runner",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "description": "Run a topology consisting of a directed acyclic graph",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topology-runner",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Run a topology consisting of a directed acyclic graph",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topology-runner",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Run a topology consisting of a directed acyclic graph",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -688,7 +688,7 @@ describe('resumeTopology', () => {
       },
     })
   })
-  test('resuming completed snapshot should be idempotent', () => {
+  test('resuming completed snapshot should be idempotent', async () => {
     const snapshot: Snapshot = {
       started: new Date('2022-01-01T12:00:00Z'),
       finished: new Date('2022-01-01T12:00:01Z'),
@@ -728,7 +728,8 @@ describe('resumeTopology', () => {
       },
       meta: { launchMissleCode: 1234 },
     }
-    const { getSnapshot } = resumeTopology(spec, snapshot)
+    const { promise, getSnapshot } = resumeTopology(spec, snapshot)
+    await promise
     expect(getSnapshot()).toEqual(snapshot)
   })
 })

--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -304,7 +304,7 @@ describe('getInputData', () => {
 
 describe('initData', () => {
   test('data passed', () => {
-    expect(initSnapshotData(dag, { data: [1, 2, 3] })).toEqual({
+    expect(initSnapshotData(dag, [1, 2, 3])).toEqual({
       api: { input: [1, 2, 3] },
     })
   })
@@ -330,18 +330,18 @@ describe('runTopology', () => {
       },
       nodes: {
         api: {
-          run: async ({ data, resources, meta }) => ({ data, resources, meta }),
+          run: async ({ data, resources, context }) => ({ data, resources, context }),
           resources: ['elasticCloud'],
         },
         details: {
-          run: async ({ data, resources, meta }) => ({ data, resources, meta }),
+          run: async ({ data, resources, context }) => ({ data, resources, context }),
           resources: ['mongoDb'],
         },
       },
     }
     const data = [1, 2, 3]
-    const meta = { launchMissleCode: 1234 }
-    const { promise, getSnapshot } = runTopology(spec, dag, { data, meta })
+    const context = { launchMissleCode: 1234 }
+    const { promise, getSnapshot } = runTopology(spec, dag, { data, context })
     await promise
     expect(getSnapshot()).toMatchObject({
       status: 'completed',
@@ -353,7 +353,7 @@ describe('runTopology', () => {
           output: {
             data: [1, 2, 3],
             resources: { elasticCloud: 'elastic' },
-            meta: { launchMissleCode: 1234 },
+            context: { launchMissleCode: 1234 },
           },
         },
         details: {
@@ -361,7 +361,7 @@ describe('runTopology', () => {
             {
               data: [1, 2, 3],
               resources: { elasticCloud: 'elastic' },
-              meta: { launchMissleCode: 1234 },
+              context: { launchMissleCode: 1234 },
             },
           ],
           status: 'completed',
@@ -370,15 +370,14 @@ describe('runTopology', () => {
               {
                 data: [1, 2, 3],
                 resources: { elasticCloud: 'elastic' },
-                meta: { launchMissleCode: 1234 },
+                context: { launchMissleCode: 1234 },
               },
             ],
             resources: { mongoDb: 'mongo' },
-            meta: { launchMissleCode: 1234 },
+            context: { launchMissleCode: 1234 },
           },
         },
       },
-      meta: { launchMissleCode: 1234 },
     })
   })
   test('bad arguments', () => {
@@ -701,7 +700,6 @@ describe('resumeTopology', () => {
           output: {
             data: [1, 2, 3],
             resources: { elasticCloud: 'elastic' },
-            meta: { launchMissleCode: 1234 },
           },
         },
         details: {
@@ -709,7 +707,6 @@ describe('resumeTopology', () => {
             {
               data: [1, 2, 3],
               resources: { elasticCloud: 'elastic' },
-              meta: { launchMissleCode: 1234 },
             },
           ],
           status: 'completed',
@@ -718,15 +715,12 @@ describe('resumeTopology', () => {
               {
                 data: [1, 2, 3],
                 resources: { elasticCloud: 'elastic' },
-                meta: { launchMissleCode: 1234 },
               },
             ],
             resources: { mongoDb: 'mongo' },
-            meta: { launchMissleCode: 1234 },
           },
         },
       },
-      meta: { launchMissleCode: 1234 },
     }
     const { promise, getSnapshot } = resumeTopology(spec, snapshot)
     await promise

--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -634,10 +634,10 @@ describe('resumeTopology', () => {
         },
       },
     })
-    const { promise: resumeProm, getSnapshot: resumeGetSnapshot } =
+    const { promise: promise2, getSnapshot: getSnapshot2 } =
       await resumeTopology(modifiedSpec, snapshot)
-    await resumeProm
-    expect(resumeGetSnapshot()).toMatchObject({
+    await promise2
+    expect(getSnapshot2()).toMatchObject({
       status: 'completed',
       dag: {
         api: { deps: [] },

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -203,6 +203,7 @@ const _runTopology = (spec: Spec, snapshot: Snapshot, dag: DAG): Response => {
         emitter.emit(hasErrors ? 'error' : 'done', snapshot)
         // Cleanup initialized resources
         await cleanupResources(spec, initialized)
+        // Throw an exception with the errors, causing the promise to reject
         if (hasErrors) {
           throw new TopologyError(`Errored nodes: ${JSON.stringify(errored)}`)
         }

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -200,14 +200,13 @@ const _runTopology = (spec: Spec, snapshot: Snapshot, dag: DAG): Response => {
         snapshot.status = hasErrors ? 'errored' : 'completed'
         snapshot.finished = new Date()
         // Emit
-        emitter.emit('data', snapshot)
         emitter.emit(hasErrors ? 'error' : 'done', snapshot)
         // Cleanup initialized resources
         await cleanupResources(spec, initialized)
         if (hasErrors) {
           throw new TopologyError(`Errored nodes: ${JSON.stringify(errored)}`)
         }
-        return snapshot
+        return
       }
 
       // Run nodes
@@ -341,7 +340,7 @@ export const resumeTopology = (spec: Spec, snapshot: Snapshot): Response => {
   if (snapshot.status === 'completed') {
     const emitter = new EventEmitter<Events>()
     const getSnapshot = () => snapshot
-    return { emitter, promise: Promise.resolve(snapshot), getSnapshot }
+    return { emitter, promise: Promise.resolve(), getSnapshot }
   }
   // Initialize snapshot for running
   const snap = getResumeSnapshot(snapshot)

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -8,8 +8,10 @@ import {
   RunInput,
   Spec,
   SnapshotData,
-  Response,
   Initialized,
+  RunTopologyInternal,
+  ResumeTopology,
+  RunTopology,
 } from './types'
 import { missingKeys, findKeys } from './util'
 import EventEmitter from 'eventemitter3'
@@ -172,7 +174,7 @@ const nodeEventHandler = (
 export const getMissingSpecNodes = (spec: Spec, dag: DAG) =>
   _.difference(Object.keys(dag), Object.keys(spec.nodes))
 
-const _runTopology = (spec: Spec, snapshot: Snapshot, dag: DAG): Response => {
+const _runTopology: RunTopologyInternal = (spec, snapshot, dag, context) => {
   const missingSpecNodes = getMissingSpecNodes(spec, dag)
   if (missingSpecNodes.length) {
     throw new TopologyError(
@@ -242,7 +244,7 @@ const _runTopology = (spec: Spec, snapshot: Snapshot, dag: DAG): Response => {
           updateState,
           state,
           signal: abortController.signal,
-          meta: snapshot?.meta,
+          context,
         }
         // Update snapshot
         events.running(data)
@@ -265,12 +267,11 @@ const _runTopology = (spec: Spec, snapshot: Snapshot, dag: DAG): Response => {
   return { emitter, promise: run(), getSnapshot }
 }
 
-/*
- * Set input for nodes with no dependencies to options.data,
- * if exists.
+/**
+ * Set input for nodes with no dependencies to data, if exists.
  */
-export const initSnapshotData = (dag: DAG, options: Options = {}) => {
-  if (!_.has('data', options)) {
+export const initSnapshotData = (dag: DAG, data?: any) => {
+  if (_.isEmpty(data)) {
     return {}
   }
   // Get nodes with no dependencies
@@ -280,7 +281,7 @@ export const initSnapshotData = (dag: DAG, options: Options = {}) => {
   )
   // Initialize data
   return noDepsNodes.reduce(
-    (acc, node) => _.set([node, 'input'], options.data, acc),
+    (acc, node) => _.set([node, 'input'], data, acc),
     {}
   )
 }
@@ -288,27 +289,27 @@ export const initSnapshotData = (dag: DAG, options: Options = {}) => {
 /**
  * Run a topology consisting of a DAG and functions for each node in the
  * DAG. A subset of the DAG can be executed by setting either includeNodes
- * or excludeNodes. Initial data is passed via options.data.
+ * or excludeNodes. Initial data is passed via options.data. Optionally
+ * pass a context blob to all nodes.
+
  *
  * Returns an event emitter and a promise. The event emitter emits data
- * every time the topology snapshot updates, done when the topology completes,
- * and error when a node throws an error.
+ * every time the topology snapshot updates.
  */
-export const runTopology = (spec: Spec, inputDag: DAG, options?: Options) => {
+export const runTopology: RunTopology = (spec, inputDag, options) => {
   // Get the filtered dag
   const dag = filterDAG(inputDag, options)
   // Initialize snapshot data
-  const data = initSnapshotData(dag, options)
+  const data = initSnapshotData(dag, options?.data)
   // Initial snapshot
   const snapshot: Snapshot = {
     status: 'running',
     started: new Date(),
     dag,
     data,
-    meta: options?.meta,
   }
   // Run the topology
-  return _runTopology(spec, snapshot, dag)
+  return _runTopology(spec, snapshot, dag, options?.context)
 }
 
 /**
@@ -334,9 +335,13 @@ export const getResumeSnapshot = (snapshot: Snapshot) => {
   return snap
 }
 /**
- * Resume a topology from a previous snapshot.
+ * Resume a topology from a previous snapshot. Optionally pass a context
+ * blob to all nodes.
+ *
+ * Returns an event emitter and a promise. The event emitter emits data
+ * every time the topology snapshot updates.
  */
-export const resumeTopology = (spec: Spec, snapshot: Snapshot): Response => {
+export const resumeTopology: ResumeTopology = (spec, snapshot, options) => {
   // Ensures resumption is idempotent
   if (snapshot.status === 'completed') {
     const emitter = new EventEmitter<Events>()
@@ -346,5 +351,5 @@ export const resumeTopology = (spec: Spec, snapshot: Snapshot): Response => {
   // Initialize snapshot for running
   const snap = getResumeSnapshot(snapshot)
   // Run the topology
-  return _runTopology(spec, snap, snap.dag)
+  return _runTopology(spec, snap, snap.dag, options?.context)
 }

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -203,7 +203,7 @@ const _runTopology = (spec: Spec, snapshot: Snapshot, dag: DAG): Response => {
         emitter.emit(hasErrors ? 'error' : 'done', snapshot)
         // Cleanup initialized resources
         await cleanupResources(spec, initialized)
-        // Throw an exception with the errors, causing the promise to reject
+        // Throw an exception, causing the promise to reject
         if (hasErrors) {
           throw new TopologyError(`Errored nodes: ${JSON.stringify(errored)}`)
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export interface Options {
 
 export type Response = {
   emitter: EventEmitter<Events, any>
-  promise: Promise<Snapshot>
+  promise: Promise<void>
   getSnapshot: () => Snapshot
 }
 export type Status = 'pending' | 'running' | 'completed' | 'errored'

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface RunInput {
   updateState: UpdateState
   state?: any
   signal: AbortSignal
-  meta?: any
+  context?: any
 }
 
 type Millis = number
@@ -37,7 +37,7 @@ export interface Options {
   includeNodes?: string[]
   excludeNodes?: string[]
   data?: any // Fed into starting nodes (i.e., nodes with no dependencies)
-  meta?: any // Fed to all nodes
+  context?: any // Fed to all nodes
 }
 
 export type Response = {
@@ -65,9 +65,28 @@ export interface Snapshot {
   finished?: Date
   dag: DAG
   data: SnapshotData
-  meta?: any
+  context?: any
 }
 
 export type ObjectOfPromises = Record<string | number, Promise<any>>
 
 export type Events = 'data' | 'error' | 'done'
+
+export type RunTopology = (
+  spec: Spec,
+  inputDag: DAG,
+  options?: Options
+) => Response
+
+export type RunTopologyInternal = (
+  spec: Spec,
+  snapshot: Snapshot,
+  dag: DAG,
+  context: any
+) => Response
+
+export type ResumeTopology = (
+  spec: Spec,
+  snapshot: Snapshot,
+  options?: Pick<Options, 'context'>
+) => Response


### PR DESCRIPTION
* `runTopology` and `resumeTopology` return `{promise: Promise<void>, ...}` instead of `{promise: Promise<Snapshot>, ...}`.
* Don't emit `data` when finished.