### PR TITLE
Merge Spec and DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Snapshot data includes `deps`. Removed `dag`.
 * Get error stacktrace if available.
 * Wrap initial input data in an array to match other nodes.
+* Removed `resources`.
 
 # 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.7.0
 
 * Spec includes `deps` so you can just pass one object.
+* Snapshot data includes `deps`. Removed `dag`.
 * Get error stacktrace if available.
 * Wrap initial input data in an array to match other nodes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.7.0
+
+* Spec includes `deps` so you can just pass one object.
+* Get error stacktrace if available.
+* Wrap initial input data in an array to match other nodes.
+
 # 0.6.0
 
 * Handle empty snapshot when resuming.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topology-runner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "topology-runner",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topology-runner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Run a topology consisting of a directed acyclic graph",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -244,7 +244,7 @@ describe('initData', () => {
     })
   })
   test('data empty', () => {
-    expect(initSnapshotData(dag, {})).toEqual({})
+    expect(initSnapshotData(dag)).toEqual({})
   })
 })
 

--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -395,7 +395,7 @@ describe('runTopology', () => {
           input: [],
           status: 'errored',
           state: { index: 1 },
-          error: expect.stringContaining('Error: Aborted'),
+          error: { stack: expect.stringContaining('Error: Aborted') },
         },
       },
     })
@@ -527,7 +527,9 @@ describe('resumeTopology', () => {
           deps: ['api'],
           input: [[1, 2, 3]],
           status: 'errored',
-          error: expect.stringContaining('Error: Failed processing id: 2'),
+          error: {
+            stack: expect.stringContaining('Error: Failed processing id: 2'),
+          },
           state: {
             index: 0,
             output: {

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -223,7 +223,7 @@ const _runTopology: RunTopologyInternal = (spec, dag, snapshot, context) => {
 /**
  * Set input for nodes with no dependencies to data, if exists.
  */
-export const initSnapshotData = (dag: DAG, data?: any) => {
+export const initSnapshotData = (dag: DAG, data?: any): SnapshotData => {
   if (_.isEmpty(data)) {
     return {}
   }
@@ -252,7 +252,7 @@ export const initSnapshotData = (dag: DAG, data?: any) => {
  */
 export const runTopology: RunTopology = (spec, options) => {
   const _dag: DAG = _.mapValues<NodeDef, { deps: string[] }>(
-    _.omit('run'),
+    _.pick('deps'),
     spec
   )
   // Get the filtered dag

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,10 +38,11 @@ export type Response = {
 export type Status = 'pending' | 'running' | 'completed' | 'errored'
 
 export interface NodeData {
-  status?: Status
+  deps: string[],
+  status: Status
   started?: Date
   finished?: Date
-  input: any
+  input?: any
   output?: any
   state?: any
   error?: any
@@ -53,7 +54,6 @@ export interface Snapshot {
   status: Status
   started: Date
   finished?: Date
-  dag: DAG
   data: SnapshotData
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,9 @@
 import EventEmitter from 'eventemitter3'
 
-interface Resource<A> {
-  init(): Promise<A> | A
-  cleanup?(resource: A): Promise<void> | void
-}
-
-type ResourceInitializers = Record<string, Resource<any>>
 type UpdateState = (state: any) => void
 export type Initialized = Record<string, any>
 
 export interface RunInput {
-  resources: Record<string, any>
   data: any
   updateState: UpdateState
   state?: any
@@ -21,16 +14,13 @@ export interface RunInput {
 
 export type RunFn = (arg: RunInput) => Promise<any>
 
-interface NodeDef {
+export interface NodeDef {
   run: RunFn
-  resources?: string[]
+  deps: string[]
 }
-export type DAG = Record<string, { deps: string[] }>
 
-export interface Spec {
-  resources?: ResourceInitializers
-  nodes: Record<string, NodeDef>
-}
+export type DAG = Record<string, { deps: string[] }>
+export type Spec = Record<string, NodeDef>
 
 export interface Options {
   includeNodes?: string[]
@@ -65,7 +55,6 @@ export interface Snapshot {
   finished?: Date
   dag: DAG
   data: SnapshotData
-  context?: any
 }
 
 export type ObjectOfPromises = Record<string | number, Promise<any>>
@@ -74,14 +63,13 @@ export type Events = 'data' | 'error' | 'done'
 
 export type RunTopology = (
   spec: Spec,
-  inputDag: DAG,
   options?: Options
 ) => Response
 
 export type RunTopologyInternal = (
   spec: Spec,
-  snapshot: Snapshot,
   dag: DAG,
+  snapshot: Snapshot,
   context: any
 ) => Response
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { missingKeys, findKeys } from './util'
+import { findKeys } from './util'
 
 describe('findKeys', () => {
   test('should find keys', () => {
@@ -10,16 +10,5 @@ describe('findKeys', () => {
     }
     const keys = findKeys({ status: 'completed' }, data)
     expect(keys).toEqual(['api', 'attachments'])
-  })
-})
-
-describe('missingKeys', () => {
-  test('should find keys', () => {
-    const obj = {
-      elastic: {},
-      config: {},
-    }
-    const missing = missingKeys(['elastic', 'mongodb'], obj)
-    expect(missing).toEqual(['mongodb'])
   })
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ import _ from 'lodash/fp'
 /**
  * Find keys where values match pred. pred can be a lodash iteratee.
  */
-export const findKeys = (pred: string | object, obj: Record<string, any>) => {
+export function findKeys<A = any>(pred: string | object, obj: Record<string, A>) {
   const iteratee = _.iteratee(pred)
   const keys = []
   for (const key in obj) {
@@ -14,9 +14,3 @@ export const findKeys = (pred: string | object, obj: Record<string, any>) => {
   }
   return keys
 }
-
-/**
- * Returns the keys from those passed that are missing in obj.
- */
-export const missingKeys = (keys: string[], obj: object) =>
-  _.flow(Object.keys, _.difference(keys))(obj)


### PR DESCRIPTION
* Spec includes `deps` so you can just pass one object.
* Snapshot data includes `deps`. Removed `dag`.
* Get error stacktrace if available.
* Wrap initial input data in an array to match other nodes.
* Removed `resources`.