### PR TITLE
Changed promise to start()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0
+
+* BREAKING CHANGE: Changed `promise` to `start` fn.
+
 # 0.7.0
 
 * Spec includes `deps` so you can just pass one object.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 runTopology(spec: Spec, options?: Options) => Response
 
 type Response = {
-  emitter: EventEmitter<Events,any>,
-  promise: Promise<Snapshot>,
-  getSnapshot: () => Snapshot
+  start(): Promise<void>
+  stop(): void
+  emitter: EventEmitter<Events, any>
+  getSnapshot(): Snapshot
 }
 ```
 
@@ -124,7 +125,7 @@ const spec: Spec = {
   },
 }
 
-const { emitter, promise, getSnapshot } = runTopology(spec)
+const { start, emitter, getSnapshot } = runTopology(spec)
 
 const persistSnapshot = (snapshot) => {
   // Could be Redis, MongoDB, etc.
@@ -137,7 +138,7 @@ emitter.on('data', persistSnapshot)
 
 try {
   // Wait for the topology to finish
-  await promise
+  await start()
 } finally {
   // Persist the final snapshot
   await persistSnapshot(getSnapshot())
@@ -249,12 +250,6 @@ runTopology(spec, { excludeNodes: ['downloadFile'], data: ['123', '456'] })
 
 ```typescript
 resumeTopology(spec: Spec, snapshot: Snapshot) => Response
-
-type Response = {
-  emitter: EventEmitter<Events,any>,
-  promise: Promise<Snapshot>,
-  getSnapshot: () => Snapshot
-}
 ```
 
 Allows you to resume a topology from a previously emitted snapshot.
@@ -263,8 +258,8 @@ Each node should maintain its state via the `updateState` callback.
 ```typescript
 import { resumeTopology } from 'topology-runner'
 
-const { emitter, promise } = resumeTopology(spec, snapshot)
-await promise
+const { start, emitter } = resumeTopology(spec, snapshot)
+await start()
 ```
 
 Below is an example snapshot where an error occurred. The DAG

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topology-runner",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Run a topology consisting of a directed acyclic graph",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/topology.test.ts
+++ b/src/topology.test.ts
@@ -290,8 +290,8 @@ describe('runTopology', () => {
     }
     const data = [1, 2, 3]
     const context = { launchMissleCode: 1234 }
-    const { promise, getSnapshot } = runTopology(spec, { data, context })
-    await promise
+    const { start, getSnapshot } = runTopology(spec, { data, context })
+    await start()
     expect(getSnapshot()).toMatchObject({
       status: 'completed',
       data: {
@@ -325,8 +325,8 @@ describe('runTopology', () => {
     })
   })
   test('completed', async () => {
-    const { promise, getSnapshot } = runTopology(spec, dag)
-    await promise
+    const { start, getSnapshot } = runTopology(spec, dag)
+    await start()
     expect(getSnapshot()).toMatchObject({
       status: 'completed',
       data: {
@@ -384,9 +384,9 @@ describe('runTopology', () => {
       },
     }
 
-    const { promise, getSnapshot, stop } = runTopology(spec, dag)
+    const { start, stop, getSnapshot } = runTopology(spec, dag)
     setTimeout(stop, 200)
-    await expect(promise).rejects.toThrow('Errored nodes: ["api"]')
+    await expect(start()).rejects.toThrow('Errored nodes: ["api"]')
     // Node errored
     expect(getSnapshot()).toMatchObject({
       status: 'errored',
@@ -501,8 +501,8 @@ describe('resumeTopology', () => {
   const modifiedSpec = _.set('attachments.run', attachmentsRun, spec)
 
   test('resume after initial error', async () => {
-    const { promise, getSnapshot } = runTopology(modifiedSpec, dag)
-    await expect(promise).rejects.toThrow('Errored nodes: ["attachments"]')
+    const { start, getSnapshot } = runTopology(modifiedSpec, dag)
+    await expect(start()).rejects.toThrow('Errored nodes: ["attachments"]')
     const snapshot = getSnapshot()
     expect(snapshot).toMatchObject({
       status: 'errored',
@@ -539,9 +539,11 @@ describe('resumeTopology', () => {
         },
       },
     })
-    const { promise: promise2, getSnapshot: getSnapshot2 } =
-      await resumeTopology(modifiedSpec, snapshot)
-    await promise2
+    const { start: start2, getSnapshot: getSnapshot2 } = await resumeTopology(
+      modifiedSpec,
+      snapshot
+    )
+    await start2()
     expect(getSnapshot2()).toMatchObject({
       status: 'completed',
       data: {
@@ -623,8 +625,8 @@ describe('resumeTopology', () => {
         },
       },
     }
-    const { promise, getSnapshot } = resumeTopology(spec, snapshot)
-    await promise
+    const { start, getSnapshot } = resumeTopology(spec, snapshot)
+    await start()
     expect(getSnapshot()).toEqual(snapshot)
   })
   test('should throw if snapshot is undefined', async () => {

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -146,10 +146,11 @@ const _runTopology: RunTopologyInternal = (spec, dag, snapshot, context) => {
   const promises: ObjectOfPromises = {}
   // Event emitter
   const emitter = new EventEmitter<Events>()
-  // Emit initial snapshot
-  emitter.emit('data', snapshot)
 
-  const run = async () => {
+  const start = async () => {
+    // Emit initial snapshot
+    emitter.emit('data', snapshot)
+    // Loop
     while (true) {
       // Get nodes with resolved dependencies that have not been run
       const readyToRunNodes = abortController.signal.aborted
@@ -217,7 +218,7 @@ const _runTopology: RunTopologyInternal = (spec, dag, snapshot, context) => {
     abortController.abort()
   }
 
-  return { emitter, promise: run(), getSnapshot, stop }
+  return { start, stop, emitter, getSnapshot }
 }
 
 const getNodesWithNoDeps = (dag: DAG) =>
@@ -316,7 +317,7 @@ export const resumeTopology: ResumeTopology = (spec, snapshot, options) => {
     const getSnapshot = () => snapshot
     /* eslint-disable-next-line */
     const stop = () => {}
-    return { emitter, promise: Promise.resolve(), getSnapshot, stop }
+    return { start: () => Promise.resolve(), stop, emitter, getSnapshot }
   }
   // Initialize snapshot for running
   const snap = getResumeSnapshot(snapshot)

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,15 +30,15 @@ export interface Options {
 }
 
 export type Response = {
-  emitter: EventEmitter<Events, any>
-  promise: Promise<void>
-  getSnapshot(): Snapshot
+  start(): Promise<void>
   stop(): void
+  emitter: EventEmitter<Events, any>
+  getSnapshot(): Snapshot
 }
-export type Status = 'pending' | 'running' | 'completed' | 'errored'
+export type Status = 'pending' | 'running' | 'completed' | 'errored' | 'aborted'
 
 export interface NodeData {
-  deps: string[],
+  deps: string[]
   status: Status
   started?: Date
   finished?: Date
@@ -61,10 +61,7 @@ export type ObjectOfPromises = Record<string | number, Promise<any>>
 
 export type Events = 'data' | 'error' | 'done'
 
-export type RunTopology = (
-  spec: Spec,
-  options?: Options
-) => Response
+export type RunTopology = (spec: Spec, options?: Options) => Response
 
 export type RunTopologyInternal = (
   spec: Spec,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export type Response = {
   emitter: EventEmitter<Events, any>
   getSnapshot(): Snapshot
 }
-export type Status = 'pending' | 'running' | 'completed' | 'errored' | 'aborted'
+export type Status = 'pending' | 'running' | 'completed' | 'errored'
 
 export interface NodeData {
   deps: string[]


### PR DESCRIPTION
Changed `promise` to `start()` to ensure all emitted events are received.